### PR TITLE
Add Partial Search Functionality for Author Names

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         <p class="u-mobile-only" data-button>Tap <span>here</span> for more</p>
       </div>
       <div class="aligner">
+        <div class="author" id="author"></div>
         <div class="quote" id="quote"></div>
       </div>
     </main>

--- a/main.css
+++ b/main.css
@@ -59,21 +59,22 @@ p span {
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-direction: column;
     height: 100vh;
+    text-align: center;
+    max-width: 600px;
+    padding: 0 20px;
+    margin: 0 auto;
 }
 
 .quote {
     position: relative;
-    margin: 50px auto 0;
-    padding: 0 20px;
     font-size: 45px;
-    text-align: center;
     font-weight: 300;
-    max-width: 600px;
     text-shadow: 1px 2px #0c4271;
 }
 
-.quote > div {
+.author {
     font-size: 18px;
     margin-bottom: 15px;
     text-transform: uppercase;

--- a/main.js
+++ b/main.js
@@ -2907,24 +2907,45 @@ const data = {
 };
 
 const quoteContainer = document.getElementById("quote");
+const authorContainer = document.getElementById("author");
 
 const quotes = Object.keys(data).reduce(
   (quoteArray, key) => [...quoteArray, data[key]],
   []
 );
 
-// Get random quote
+// Get the author from the URL query parameter
+function getAuthorFromURL() {
+  const urlParams = new URLSearchParams(window.location.search);
+  const author = urlParams.get('author')?.trim().toLowerCase(); // e.g., ?author=Author%20Name
+  if (author) {
+    return author;
+  }
+  return null;
+}
+
+// Filter quotes by the author specified in the URL
+function filterQuotesByAuthor(author) {
+  return quotes.filter(quote => quote.author.toLowerCase().includes(author));
+}
+
+// Get a random quote (with optional author filtering)
 randomQuote = () => {
-  return quotes[Math.floor(Math.random() * quotes.length)];
-};
+  const author = getAuthorFromURL();
+  let filteredQuotes = quotes;
+
+  if (author) {
+    filteredQuotes = filterQuotesByAuthor(author);
+  }
+
+  return filteredQuotes[Math.floor(Math.random() * filteredQuotes.length)];
+}
 
 // Update DOM with quote
 updateQuote = () => {
   const selectedQuote = randomQuote();
-  quoteContainer.innerHTML = `
-    <div>${selectedQuote.author}</div>
-    ${selectedQuote.saying}
-  `;
+  authorContainer.textContent = `${selectedQuote.author}`;
+  quoteContainer.textContent = `${selectedQuote.saying}`;
 };
 
 // On load

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,6 @@
 https://siimonevans.github.io/sayings
+
+## Features:
+- Display random sayings from a predefined list of authors and sayings.
+- Filter quotes by author using the ?author=<author_name> query in the URL.
+- Press the spacebar or tap a button to view a new random quote.


### PR DESCRIPTION
This pull request enhances the sayings app by improving the display of quotes and adding the ability to filter quotes by author via a URL query parameter. The UI layout is refined for better readability, and author information is now displayed separately from the quote.

**Feature enhancements:**

* Added support for filtering quotes by author using the `?author=<author_name>` query parameter in the URL. The app now displays only quotes matching the specified author.
* Updated the `readme.md` to document the new author filtering feature and other app capabilities.

**UI improvements:**

* Modified the layout to display the author in a dedicated `div` above the quote, improving readability and separation of content. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R16) [[2]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aR2910-R2948)
* Enhanced CSS for better centering, max-width, and padding, and created a distinct style for the author section.

### Example Usage:
- **URL**: `https://siimonevans.github.io/sayings?author=steve`
- Matches: `"Steve S"` (removes spaces and makes the search case-insensitive).

### How to Test:
1. Test with various author names by appending the `author=<name>` query to the URL.
2. Ensure that searching for partial author names (e.g., `nick%20l` for `"Nick L"`) returns the correct quotes.
3. Check that normal author searches (e.g., `steve` for `"Steve Jobs"`) work as expected.
4. Check that app still shows quotes when no author names are provided.